### PR TITLE
fix(prisma-config): missing import dotenv

### DIFF
--- a/src/templates/db.ts
+++ b/src/templates/db.ts
@@ -20,6 +20,7 @@ export const driverNames: Record<Preferences["driver"], string> = {
 export function getDBIndex({ orm, driver, packageManager }: Preferences) {
 	if (orm === "Prisma")
 		return [
+			`import "dotenv/config""`,
 			`import { PrismaClient } from "@prisma/client"`,
 			"",
 			"export const prisma = new PrismaClient()",


### PR DESCRIPTION
Close #268 
Please add `import "dotenv/config";` to your `prisma.config.ts` file, or use the Prisma CLI with Bun
to load environment variables from .env files: https://pris.ly/prisma-config-env-vars. 