### PR TITLE
fix(docker): update postgres volume mount for pg 18

### DIFF
--- a/src/templates/docker.ts
+++ b/src/templates/docker.ts
@@ -135,7 +135,7 @@ export function getDockerCompose({
                 - POSTGRES_PASSWORD=${meta.databasePassword}
                 - POSTGRES_DB=${projectName}
             volumes:
-                - postgres_data:/var/lib/postgresql/data`
+                - postgres_data:/var/lib/postgresql`
 			: "",
 		redis
 			? /* yaml */ `redis:
@@ -205,7 +205,7 @@ export function getDevelopmentDockerCompose({
             ports:
                 - 5432:5432
             volumes:
-                - postgres_data:/var/lib/postgresql/data`
+                - postgres_data:/var/lib/postgresql`
 			: "",
 		redis
 			? /* yaml */ `redis:


### PR DESCRIPTION
fixes:
```
Error: in 18+, these Docker images are configured to store database data in a
format which is compatible with "pg_ctlcluster" (specifically, using
major-version-specific directory names). This better reflects how
PostgreSQL itself works, and how upgrades are to be performed.
```